### PR TITLE
support polymorphic Nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ $.Null :: Type
 
 Type whose sole member is `null`.
 
+#### `Nullable`
+
+```haskell
+$.Nullable :: Type -> Type
+```
+
+Constructor for types which include `null` as a member.
+
 #### `Number`
 
 ```haskell
@@ -539,38 +547,6 @@ dist({x: 0, y: 0}, {x: NaN, y: NaN});
 
 dist(0);
 // ! TypeError: ‘dist’ expected a value of type { x :: FiniteNumber, y :: FiniteNumber } as its first argument; received 0
-```
-
-#### `Nullable`
-
-`Nullable` is used to construct types which include `null` as a member.
-
-To define `t :: Nullable a` one must provide:
-
-  - the type of `a` (exposed as `t.$1`).
-
-```haskell
-Nullable :: Type -> Type
-```
-
-For example:
-
-```javascript
-//    toUpper :: Nullable String -> Nullable String
-const toUpper =
-def('toUpper',
-    {},
-    [$.Nullable($.String), $.Nullable($.String)],
-    nullable => nullable === null ? null : nullable.toUpperCase());
-
-toUpper(null);
-// => null
-
-toUpper('abc');
-// => 'ABC'
-
-toUpper(['abc']);
-// ! TypeError: ‘toUpper’ expected a value of type (Nullable String) as its first argument; received ["abc"]
 ```
 
 ### Type classes

--- a/test/index.js
+++ b/test/index.js
@@ -529,6 +529,8 @@ describe('def', function() {
   });
 
   it('supports "nullable" types', function() {
+    var def = $.create($.env.concat([$.Nullable]));
+
     //  toUpper :: Nullable String -> Nullable String
     var toUpper =
     def('toUpper',
@@ -543,6 +545,32 @@ describe('def', function() {
            errorEq(TypeError,
                    '‘toUpper’ expected a value of type (Nullable String) ' +
                    'as its first argument; received ["abc"]'));
+
+    //  defaultTo :: a -> Nullable a -> a
+    var defaultTo =
+    def('defaultTo',
+        {},
+        [a, $.Nullable(a), a],
+        function(x, nullable) { return nullable === null ? x : nullable; });
+
+    eq(defaultTo(0, null), 0);
+    eq(defaultTo(0, 42), 42);
+
+    throws(function() { defaultTo(0, 'XXX'); },
+           errorEq(TypeError,
+                   '‘defaultTo’ expected a value of type (Nullable Number) ' +
+                   'as its second argument; received "XXX"'));
+
+    //  f :: Nullable a -> Nullable a
+    var f = def('f', {}, [$.Nullable(a), $.Nullable(a)], R.always(42));
+
+    eq(f(null), 42);
+    eq(f(0), 42);
+
+    throws(function() { f('XXX'); },
+           errorEq(TypeError,
+                   '‘f’ is expected to return a value of type ' +
+                   '(Nullable String); returned 42'));
   });
 
   it('uses R.toString-like string representations', function() {


### PR DESCRIPTION
#9 did not support types such as `Nullable a -> Nullable a` and `a -> Nullable a -> a`. This change addresses the shortcoming.

The new implementation defines `$.Nullable` via `$.UnaryType`, as this turned out to be simpler. This necessitated the addition of a `t.name === 'sanctuary-def/Nullable'` check, which is unfortunate. I haven't thought of a simpler way to avoid `(Nullable (Nullable (Nullable ...)))` infinite recursion.
