### PR TITLE
Run tests against Node 4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,5 @@ test:
     - nvm install 0.12.7
     - nvm alias default 0.12.7
     - make test
+    - nvm use 4 && make test
+    - nvm use 5 && make test


### PR DESCRIPTION
Node 4 is the officially released version of node.js with LTS. We should be running our tests against it. I've also added tests for Node 5. Luckily these are already installed on the CircleCI container so we can just use them with `nvm use`. If we were to drop support for Node 0.10, which is EOL in October, then we could set the base Node version to 0.12.7 and not have to do any installs at all.