### PR TITLE
types: define {Positive,Negative}{Number,FiniteNumber}

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ constructors such as [`SyntaxError`][2] and [`TypeError`][3].
 $.FiniteNumber :: Type
 ```
 
-Type comprising every [`ValidNumber`](#validnumber) value except `Infinity` and 
+Type comprising every [`ValidNumber`](#validnumber) value except `Infinity` and
 `-Infinity` (and their object counterparts).
 
 #### `Function`
@@ -194,8 +194,16 @@ Type comprising every Function value.
 $.Integer :: Type
 ```
 
-Type comprising every integer in the range 
+Type comprising every integer in the range
 [[`Number.MIN_SAFE_INTEGER`][4] .. [`Number.MAX_SAFE_INTEGER`][5]].
+
+#### `NegativeFiniteNumber`
+
+```haskell
+$.NegativeFiniteNumber :: Type
+```
+
+Type comprising every [`FiniteNumber`](#finitenumber) value less than zero.
 
 #### `NegativeInteger`
 
@@ -205,13 +213,21 @@ $.NegativeInteger :: Type
 
 Type comprising every [`Integer`](#integer) value less than zero.
 
+#### `NegativeNumber`
+
+```haskell
+$.NegativeNumber :: Type
+```
+
+Type comprising every [`Number`](#number) value less than zero.
+
 #### `NonZeroFiniteNumber`
 
 ```haskell
 $.NonZeroFiniteNumber :: Type
 ```
 
-Type comprising every [`FiniteNumber`](#finitenumber) value except `0` and `-0` 
+Type comprising every [`FiniteNumber`](#finitenumber) value except `0` and `-0`
 (and their object counterparts).
 
 #### `NonZeroInteger`
@@ -268,6 +284,14 @@ Type comprising every "plain" Object value. Specifically, values created via:
   - the `new` operator in conjunction with `Object` or a custom
     constructor function.
 
+#### `PositiveFiniteNumber`
+
+```haskell
+$.PositiveFiniteNumber :: Type
+```
+
+Type comprising every [`FiniteNumber`](#finitenumber) value greater than zero.
+
 #### `PositiveInteger`
 
 ```haskell
@@ -275,6 +299,14 @@ $.PositiveInteger :: Type
 ```
 
 Type comprising every [`Integer`](#integer) value greater than zero.
+
+#### `PositiveNumber`
+
+```haskell
+$.PositiveNumber :: Type
+```
+
+Type comprising every [`Number`](#number) value greater than zero.
 
 #### `RegExp`
 
@@ -314,7 +346,7 @@ Type comprising every [`Date`](#date) value except `new Date(NaN)`.
 $.ValidNumber :: Type
 ```
 
-Type comprising every [`Number`](#number) value except `NaN` (and its object 
+Type comprising every [`Number`](#number) value except `NaN` (and its object
 counterpart).
 
 ### `env`
@@ -616,7 +648,7 @@ def('convertTo',
         case 'hours':        return recur('minutes', date) / 60;
       }
     });
-    
+
 convertTo('seconds', new Date(1000));
 // => 1
 

--- a/index.js
+++ b/index.js
@@ -373,62 +373,86 @@
   ];
 
   //  ValidDate :: Type
-  $.ValidDate = $.NullaryType(
+  $.ValidDate = NullaryType(
     'sanctuary-def/ValidDate',
     function(x) { return $.Date.test(x) && !isNaN(x.valueOf()); }
   );
 
+  //  PositiveNumber :: Type
+  $.PositiveNumber = NullaryType(
+    'sanctuary-def/PositiveNumber',
+    function(x) { return $.Number.test(x) && x > 0; }
+  );
+
+  //  NegativeNumber :: Type
+  $.NegativeNumber = NullaryType(
+    'sanctuary-def/NegativeNumber',
+    function(x) { return $.Number.test(x) && x < 0; }
+  );
+
   //  ValidNumber :: Type
-  $.ValidNumber = $.NullaryType(
+  var ValidNumber = $.ValidNumber = NullaryType(
     'sanctuary-def/ValidNumber',
     function(x) { return $.Number.test(x) && !isNaN(x); }
   );
 
-  //  FiniteNumber :: Type
-  $.FiniteNumber = $.NullaryType(
-    'sanctuary-def/FiniteNumber',
-    function(x) { return $.ValidNumber.test(x) && isFinite(x); }
+  //  NonZeroValidNumber :: Type
+  $.NonZeroValidNumber = NullaryType(
+    'sanctuary-def/NonZeroValidNumber',
+    function(x) { return ValidNumber.test(x) && x != 0; }
   );
 
-  //  NonZeroValidNumber :: Type
-  $.NonZeroValidNumber = $.NullaryType(
-    'sanctuary-def/NonZeroValidNumber',
-    function(x) { return $.ValidNumber.test(x) && x != 0; }
+  //  FiniteNumber :: Type
+  var FiniteNumber = $.FiniteNumber = NullaryType(
+    'sanctuary-def/FiniteNumber',
+    function(x) { return ValidNumber.test(x) && isFinite(x); }
+  );
+
+  //  PositiveFiniteNumber :: Type
+  $.PositiveFiniteNumber = NullaryType(
+    'sanctuary-def/PositiveFiniteNumber',
+    function(x) { return FiniteNumber.test(x) && x > 0; }
+  );
+
+  //  NegativeFiniteNumber :: Type
+  $.NegativeFiniteNumber = NullaryType(
+    'sanctuary-def/NegativeFiniteNumber',
+    function(x) { return FiniteNumber.test(x) && x < 0; }
   );
 
   //  NonZeroFiniteNumber :: Type
-  $.NonZeroFiniteNumber = $.NullaryType(
+  $.NonZeroFiniteNumber = NullaryType(
     'sanctuary-def/NonZeroFiniteNumber',
-    function(x) { return $.FiniteNumber.test(x) && x != 0; }
+    function(x) { return FiniteNumber.test(x) && x != 0; }
   );
 
   //  Integer :: Type
-  $.Integer = $.NullaryType(
+  var Integer = $.Integer = NullaryType(
     'sanctuary-def/Integer',
     function(x) {
-      return $.ValidNumber.test(x) &&
+      return ValidNumber.test(x) &&
              Math.floor(x) == x &&
              x >= MIN_SAFE_INTEGER &&
              x <= MAX_SAFE_INTEGER;
     }
   );
 
-  //  NonZeroInteger :: Type
-  $.NonZeroInteger = $.NullaryType(
-    'sanctuary-def/NonZeroInteger',
-    function(x) { return $.Integer.test(x) && x != 0; }
-  );
-
   //  PositiveInteger :: Type
-  $.PositiveInteger = $.NullaryType(
+  $.PositiveInteger = NullaryType(
     'sanctuary-def/PositiveInteger',
-    function(x) { return $.Integer.test(x) && x > 0; }
+    function(x) { return Integer.test(x) && x > 0; }
   );
 
   //  NegativeInteger :: Type
-  $.NegativeInteger = $.NullaryType(
+  $.NegativeInteger = NullaryType(
     'sanctuary-def/NegativeInteger',
-    function(x) { return $.Integer.test(x) && x < 0; }
+    function(x) { return Integer.test(x) && x < 0; }
+  );
+
+  //  NonZeroInteger :: Type
+  $.NonZeroInteger = NullaryType(
+    'sanctuary-def/NonZeroInteger',
+    function(x) { return Integer.test(x) && x != 0; }
   );
 
   //  arity :: (Number, Function) -> Function

--- a/test/index.js
+++ b/test/index.js
@@ -648,6 +648,40 @@ describe('def', function() {
     eq(sinceEpoch(new Date(123456)), 123.456);
   });
 
+  it('supports the "PositiveNumber" type', function() {
+    eq($.PositiveNumber.name, 'sanctuary-def/PositiveNumber');
+    eq($.PositiveNumber.test(null), false);
+    eq($.PositiveNumber.test(NaN), false);
+    eq($.PositiveNumber.test(new Number(NaN)), false);
+    eq($.PositiveNumber.test(-1), false);
+    eq($.PositiveNumber.test(new Number(-1)), false);
+    eq($.PositiveNumber.test(0), false);
+    eq($.PositiveNumber.test(new Number(0)), false);
+    eq($.PositiveNumber.test(-0), false);
+    eq($.PositiveNumber.test(new Number(-0)), false);
+    eq($.PositiveNumber.test(0.5), true);
+    eq($.PositiveNumber.test(new Number(0.5)), true);
+    eq($.PositiveNumber.test(Infinity), true);
+    eq($.PositiveNumber.test(new Number(Infinity)), true);
+  });
+
+  it('supports the "NegativeNumber" type', function() {
+    eq($.NegativeNumber.name, 'sanctuary-def/NegativeNumber');
+    eq($.NegativeNumber.test(null), false);
+    eq($.NegativeNumber.test(NaN), false);
+    eq($.NegativeNumber.test(new Number(NaN)), false);
+    eq($.NegativeNumber.test(1), false);
+    eq($.NegativeNumber.test(new Number(1)), false);
+    eq($.NegativeNumber.test(0), false);
+    eq($.NegativeNumber.test(new Number(0)), false);
+    eq($.NegativeNumber.test(-0), false);
+    eq($.NegativeNumber.test(new Number(-0)), false);
+    eq($.NegativeNumber.test(-0.5), true);
+    eq($.NegativeNumber.test(new Number(-0.5)), true);
+    eq($.NegativeNumber.test(-Infinity), true);
+    eq($.NegativeNumber.test(new Number(-Infinity)), true);
+  });
+
   it('supports the "ValidNumber" type', function() {
     var def = $.create($.env.concat([$.ValidNumber]));
 
@@ -669,6 +703,39 @@ describe('def', function() {
 
     eq(inc(1), 2);
     eq(inc(new Number(1)), 2);
+  });
+
+  it('supports the "NonZeroValidNumber" type', function() {
+    var def = $.create($.env.concat([$.ValidNumber, $.NonZeroValidNumber]));
+
+    //  div :: ValidNumber -> NonZeroValidNumber -> ValidNumber
+    var div = def('div',
+                  {},
+                  [$.ValidNumber, $.NonZeroValidNumber, $.ValidNumber],
+                  function(a, b) { return a / b; });
+
+    throws(function() { div(3, 0); },
+           errorEq(TypeError,
+                   '‘div’ expected a value of type NonZeroValidNumber ' +
+                   'as its second argument; received 0'));
+
+    throws(function() { div(3, new Number(0)); },
+           errorEq(TypeError,
+                   '‘div’ expected a value of type NonZeroValidNumber ' +
+                   'as its second argument; received new Number(0)'));
+
+    throws(function() { div(3, -0); },
+           errorEq(TypeError,
+                   '‘div’ expected a value of type NonZeroValidNumber ' +
+                   'as its second argument; received -0'));
+
+    throws(function() { div(3, new Number(-0)); },
+           errorEq(TypeError,
+                   '‘div’ expected a value of type NonZeroValidNumber ' +
+                   'as its second argument; received new Number(-0)'));
+
+    eq(div(4, 2), 2);
+    eq(div(4, new Number(2)), 2);
   });
 
   it('supports the "FiniteNumber" type', function() {
@@ -704,37 +771,38 @@ describe('def', function() {
     eq(div(4, new Number(2)), 2);
   });
 
-  it('supports the "NonZeroValidNumber" type', function() {
-    var def = $.create($.env.concat([$.ValidNumber, $.NonZeroValidNumber]));
+  it('supports the "PositiveFiniteNumber" type', function() {
+    eq($.PositiveFiniteNumber.name, 'sanctuary-def/PositiveFiniteNumber');
+    eq($.PositiveFiniteNumber.test(null), false);
+    eq($.PositiveFiniteNumber.test(NaN), false);
+    eq($.PositiveFiniteNumber.test(new Number(NaN)), false);
+    eq($.PositiveFiniteNumber.test(Infinity), false);
+    eq($.PositiveFiniteNumber.test(new Number(Infinity)), false);
+    eq($.PositiveFiniteNumber.test(-1), false);
+    eq($.PositiveFiniteNumber.test(new Number(-1)), false);
+    eq($.PositiveFiniteNumber.test(0), false);
+    eq($.PositiveFiniteNumber.test(new Number(0)), false);
+    eq($.PositiveFiniteNumber.test(-0), false);
+    eq($.PositiveFiniteNumber.test(new Number(-0)), false);
+    eq($.PositiveFiniteNumber.test(0.5), true);
+    eq($.PositiveFiniteNumber.test(new Number(0.5)), true);
+  });
 
-    //  div :: ValidNumber -> NonZeroValidNumber -> ValidNumber
-    var div = def('div',
-                  {},
-                  [$.ValidNumber, $.NonZeroValidNumber, $.ValidNumber],
-                  function(a, b) { return a / b; });
-
-    throws(function() { div(3, 0); },
-           errorEq(TypeError,
-                   '‘div’ expected a value of type NonZeroValidNumber ' +
-                   'as its second argument; received 0'));
-
-    throws(function() { div(3, new Number(0)); },
-           errorEq(TypeError,
-                   '‘div’ expected a value of type NonZeroValidNumber ' +
-                   'as its second argument; received new Number(0)'));
-
-    throws(function() { div(3, -0); },
-           errorEq(TypeError,
-                   '‘div’ expected a value of type NonZeroValidNumber ' +
-                   'as its second argument; received -0'));
-
-    throws(function() { div(3, new Number(-0)); },
-           errorEq(TypeError,
-                   '‘div’ expected a value of type NonZeroValidNumber ' +
-                   'as its second argument; received new Number(-0)'));
-
-    eq(div(4, 2), 2);
-    eq(div(4, new Number(2)), 2);
+  it('supports the "NegativeFiniteNumber" type', function() {
+    eq($.NegativeFiniteNumber.name, 'sanctuary-def/NegativeFiniteNumber');
+    eq($.NegativeFiniteNumber.test(null), false);
+    eq($.NegativeFiniteNumber.test(NaN), false);
+    eq($.NegativeFiniteNumber.test(new Number(NaN)), false);
+    eq($.NegativeFiniteNumber.test(-Infinity), false);
+    eq($.NegativeFiniteNumber.test(new Number(-Infinity)), false);
+    eq($.NegativeFiniteNumber.test(1), false);
+    eq($.NegativeFiniteNumber.test(new Number(1)), false);
+    eq($.NegativeFiniteNumber.test(0), false);
+    eq($.NegativeFiniteNumber.test(new Number(0)), false);
+    eq($.NegativeFiniteNumber.test(-0), false);
+    eq($.NegativeFiniteNumber.test(new Number(-0)), false);
+    eq($.NegativeFiniteNumber.test(-0.5), true);
+    eq($.NegativeFiniteNumber.test(new Number(-0.5)), true);
   });
 
   it('supports the "NonZeroFiniteNumber" type', function() {


### PR DESCRIPTION
This pull request introduces the following types:

  - `PositiveNumber`
  - `NegativeNumber`
  - `PositiveFiniteNumber`
  - `NegativeFiniteNumber`

`PositiveValidNumber` would be redundant, since `PositiveNumber` excludes `NaN` by virtue or `NaN` not being positive. Similar logic applies to `NegativeValidNumber`.
