### PR TITLE
types: define RegexFlags

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,23 @@ $.RegExp :: Type
 
 Type comprising every RegExp value.
 
+#### `RegexFlags`
+
+```haskell
+$.RegexFlags :: Type
+```
+
+Type comprising the canonical RegExp flags:
+
+  - `''`
+  - `'g'`
+  - `'i'`
+  - `'m'`
+  - `'gi'`
+  - `'gm'`
+  - `'im'`
+  - `'gim'`
+
 #### `String`
 
 ```haskell

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@
   };
 
   //  EnumType :: [Any] -> Type
-  $.EnumType = function(members) {
+  var EnumType = $.EnumType = function(members) {
     var reprs = map(members, show);
     return {
       type: 'ENUM',
@@ -454,6 +454,9 @@
     'sanctuary-def/NonZeroInteger',
     function(x) { return Integer.test(x) && x != 0; }
   );
+
+  //  RegexFlags :: Type
+  $.RegexFlags = EnumType(['', 'g', 'i', 'm', 'gi', 'gm', 'im', 'gim']);
 
   //  arity :: (Number, Function) -> Function
   var arity = function(n, f) {

--- a/test/index.js
+++ b/test/index.js
@@ -977,6 +977,23 @@ describe('def', function() {
     eq(dec(new Number(-1)), -2);
   });
 
+  it('supports the "RegexFlags" type', function() {
+    eq($.RegexFlags.test(''), true);
+    eq($.RegexFlags.test('g'), true);
+    eq($.RegexFlags.test('i'), true);
+    eq($.RegexFlags.test('m'), true);
+    eq($.RegexFlags.test('gi'), true);
+    eq($.RegexFlags.test('gm'), true);
+    eq($.RegexFlags.test('im'), true);
+    eq($.RegexFlags.test('gim'), true);
+    //  String objects are not acceptable.
+    eq($.RegexFlags.test(new String('')), false);
+    //  Flags must be alphabetically ordered.
+    eq($.RegexFlags.test('mg'), false);
+    //  "Sticky" flag is not acceptable.
+    eq($.RegexFlags.test('y'), false);
+  });
+
   it('uses R.toString-like string representations', function() {
     //  f :: Null -> Null
     var f = def('f', {}, [$.Null, $.Null], function(x) { return x; });


### PR DESCRIPTION
This type will be used in the definition of [`S.regex`][1]. It's unlikely to be useful elsewhere, but there's value in defining "[well-defined][2]" types in one place.


[1]: https://github.com/plaid/sanctuary/pull/107
[2]: https://github.com/ramda/ramda/pull/1264#issuecomment-120645134
