### PR TITLE
avoid unnecessarily applying ‘show’ in EnumType membership test

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,16 +291,19 @@
 
   //  EnumType :: [Any] -> Type
   var EnumType = $.EnumType = function(members) {
+    var types = map(members, $$type);
     var reprs = map(members, show);
     return {
       '@@type': 'sanctuary-def/Type',
       type: 'ENUM',
       test: function(x) {
-        var repr = show(x);
-        for (var idx = 0; idx < reprs.length; idx += 1) {
-          if (reprs[idx] === repr) return true;
-        }
-        return false;
+        //  We use `show` to perform value-based equality checks (since we
+        //  don't have access to `R.equals` and don't want to implement it).
+        //  We avoid a lot of unnecessary work by checking the type of `x`
+        //  before determining its string representation. Only if `x` is of
+        //  the same type as one or more of the `members` do we incur the
+        //  cost of determining its string representation.
+        return types.indexOf($$type(x)) >= 0 && reprs.indexOf(show(x)) >= 0;
       },
       toString: always('(' + reprs.join(' | ') + ')')
     };

--- a/test/index.js
+++ b/test/index.js
@@ -521,6 +521,13 @@ describe('def', function() {
     //  id :: a -> a
     var id = _def('id', {}, [a, a], R.identity);
 
+    eq(id('foo'), 'foo');
+    eq(id('bar'), 'bar');
+    eq(id(true), true);
+    eq(id(false), false);
+    eq(id(42), 42);
+    eq(id(-42), -42);
+
     eq(id(['foo', true]), ['foo', true]);
 
     throws(function() { id(['foo', false]); },


### PR DESCRIPTION
This addresses an issue @Avaq encountered when using Sanctuary with [cheerio][1], documented in [Avaq/breaktuary][2]. Aldwin, please patch __node_modules/sanctuary/node_modules/sanctuary-def/index.js__ and confirm that `node breaky` is no longer breaky. :)


[1]: https://github.com/cheeriojs/cheerio
[2]: https://github.com/Avaq/breaktuary
