### PR TITLE
define StrMap type constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,17 @@ Type comprising the canonical RegExp flags:
   - `'im'`
   - `'gim'`
 
+#### `StrMap`
+
+```haskell
+$.StrMap :: Type -> Type
+```
+
+Constructor for homogeneous Object types.
+
+`{foo: 1, bar: 2, baz: 3}`, for example, is a member of `StrMap Number`;
+`{foo: 1, bar: 2, baz: 'XXX'}` is not.
+
 #### `String`
 
 ```haskell
@@ -388,6 +399,7 @@ counterpart).
   - [`$.Number`](#number)
   - [`$.Object`](#object)
   - [`$.RegExp`](#regexp)
+  - [`$.StrMap`](#strmap)
   - [`$.String`](#string)
   - [`$.Undefined`](#undefined)
 


### PR DESCRIPTION
Closes #29

```haskell
StrMap :: Type -> Type
```

I thought this would be straightforward. _It's just another unary type, like [`$.Array`][1]!_ No such luck.

The key difference between `[1, 2, 'XXX']` and `{a: 1, b: 2, c: 'XXX'}` is that the former is not a member of any type in `$.env`, whereas the latter is a member of [`$.Object`][2]. All `$.Array.test` must do is determine whether the value is an array, since there's machinery elsewhere for determining the types of a container's values. Were we to use the same approach for `$.StrMap`, `{a: 1, b: 2, c: 'XXX'}` would be considered an invalid value, because the machinery would fail to find a type of which `1`, `2`, and `'XXX'` are all members.

In order to determine whether a value is a member of `StrMap a`, we must first determine whether it's an object. If it is, we must then verify that there's at least one type in the environment of which all its values are members. Since we require access to the environment, `$.StrMap.test` cannot answer our question (without an undesirable API change). As a result we cannot simply rely on dynamic dispatch: instead, we must use the newly defined `test` function which contains a special case for `'sanctuary-def/StrMap'`.

I did warn that it wouldn't be pretty. ;)


[1]: https://github.com/plaid/sanctuary-def#array
[2]: https://github.com/plaid/sanctuary-def#object
