### PR TITLE
underline nested type variable upon type-variable constraint violation

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1504,11 +1504,69 @@ describe('def', function() {
                    'Type-variable constraint violation\n' +
                    '\n' +
                    'concat :: Array a -> Array a -> Array a\n' +
-                   '          ^^^^^^^\n' +
-                   '             1\n' +
+                   '                ^\n' +
+                   '                1\n' +
                    '\n' +
                    '1)  [1, 2, 3] :: Array Number\n' +
                    '    [Left("XXX"), Right(42)] :: Array (Either String Number)\n' +
+                   '\n' +
+                   'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+
+    //  concatNested :: [[a]] -> [[a]] -> [[a]]
+    var concatNested =
+    def('concatNested',
+        {},
+        [$.Array($.Array(a)), $.Array($.Array(a)), $.Array($.Array(a))],
+        R.always([['a', 'b', 'c'], [1, 2, 3]]));
+
+    throws(function() { concatNested([['a', 'b', 'c'], [1, 2, 3]]); },
+           errorEq(TypeError,
+                   'Type-variable constraint violation\n' +
+                   '\n' +
+                   'concatNested :: Array (Array a) -> Array (Array a) -> Array (Array a)\n' +
+                   '                             ^\n' +
+                   '                             1\n' +
+                   '\n' +
+                   '1)  "a" :: String\n' +
+                   '    "b" :: String\n' +
+                   '    "c" :: String\n' +
+                   '    1 :: Number\n' +
+                   '    2 :: Number\n' +
+                   '    3 :: Number\n' +
+                   '\n' +
+                   'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+
+    throws(function() { concatNested([], [['a', 'b', 'c'], [1, 2, 3]]); },
+           errorEq(TypeError,
+                   'Type-variable constraint violation\n' +
+                   '\n' +
+                   'concatNested :: Array (Array a) -> Array (Array a) -> Array (Array a)\n' +
+                   '                                                ^\n' +
+                   '                                                1\n' +
+                   '\n' +
+                   '1)  "a" :: String\n' +
+                   '    "b" :: String\n' +
+                   '    "c" :: String\n' +
+                   '    1 :: Number\n' +
+                   '    2 :: Number\n' +
+                   '    3 :: Number\n' +
+                   '\n' +
+                   'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+
+    throws(function() { concatNested([], []); },
+           errorEq(TypeError,
+                   'Type-variable constraint violation\n' +
+                   '\n' +
+                   'concatNested :: Array (Array a) -> Array (Array a) -> Array (Array a)\n' +
+                   '                                                                   ^\n' +
+                   '                                                                   1\n' +
+                   '\n' +
+                   '1)  "a" :: String\n' +
+                   '    "b" :: String\n' +
+                   '    "c" :: String\n' +
+                   '    1 :: Number\n' +
+                   '    2 :: Number\n' +
+                   '    3 :: Number\n' +
                    '\n' +
                    'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
   });


### PR DESCRIPTION
This pull request should not be confused with #43, which has a similar title.

_Given `f :: [[a]] -> [[a]] -> [[a]]`, evaluate `f([['a', 'b', 'c'], [1, 2, 3]])`._

Before:

    Type-variable constraint violation

    concatNested :: Array (Array a) -> Array (Array a) -> Array (Array a)
                    ^^^^^^^^^^^^^^^
                           1

    1)  "a" :: String
        "b" :: String
        "c" :: String
        1 :: Number
        2 :: Number
        3 :: Number

    Since there is no type of which all the above values are members, the type-variable constraint has been violated.

After:

    Type-variable constraint violation

    concatNested :: Array (Array a) -> Array (Array a) -> Array (Array a)
                                 ^
                                 1

    1)  "a" :: String
        "b" :: String
        "c" :: String
        1 :: Number
        2 :: Number
        3 :: Number

    Since there is no type of which all the above values are members, the type-variable constraint has been violated.
