### PR TITLE
remove the requirement that all types be in the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,6 @@ counterpart).
 
 `$.env` is a list of [types](#types):
 
-  - [`$.Any`](#any)
   - [`$.Array`](#array)
   - [`$.Boolean`](#boolean)
   - [`$.Date`](#date)

--- a/test/index.js
+++ b/test/index.js
@@ -788,28 +788,6 @@ describe('def', function() {
     var env = $.env.concat([Integer, $Pair, AnonMaybe]);
     var def = $.create(true, env);
 
-    var T = $.Array($Pair($.String, Maybe($.Number)));
-
-    throws(function() { def('id', {}, [T, T], R.identity); },
-           errorEq(TypeError,
-                   'Definition of ‘id’ references my-package/Maybe which is not in the environment:\n' +
-                   '\n' +
-                   '  - Array ???\n' +
-                   '  - Boolean\n' +
-                   '  - Date\n' +
-                   '  - Error\n' +
-                   '  - Function\n' +
-                   '  - Null\n' +
-                   '  - Number\n' +
-                   '  - Object\n' +
-                   '  - RegExp\n' +
-                   '  - StrMap ???\n' +
-                   '  - String\n' +
-                   '  - Undefined\n' +
-                   '  - Integer\n' +
-                   '  - Pair ??? ???\n' +
-                   '  - AnonMaybe ???\n'));
-
     //  even :: Integer -> Boolean
     var even = def('even', {}, [Integer, $.Boolean], function(x) {
       return x % 2 === 0;


### PR DESCRIPTION
Commit message:

> The environment exists to support polymorphic functions. There are types one may use in a function definition which are not acceptable as the value of a type variable (the so-called inconsistent types). `$.Any` is one such type; Sanctuary's `List` is another.
>
> Removing the requirement that all types referenced in function definitions be in the environment has several benefits:
>
>   - it makes the library's learning curve smoother, since a user needn't worry about the environment until she's ready to use type variables;
>
>   - it removes noise from error messages (such as those resulting from misuse of Sanctuary's list functions); and
>
>   - it removes the need to treat `$.Any` specially, simplifying internals.
