### PR TITLE
underline invalid record value rather than entire record

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -969,24 +969,36 @@ describe('def', function() {
                    'Invalid value\n' +
                    '\n' +
                    'dist :: { x :: Number, y :: Number } -> { x :: Number, y :: Number } -> Number\n' +
-                   '        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                   '                     1\n' +
+                   '                            ^^^^^^\n' +
+                   '                              1\n' +
                    '\n' +
-                   '1)  {"x": 0, "y": null} :: Object, StrMap ???\n' +
+                   '1)  null :: Null\n' +
                    '\n' +
-                   'The value at position 1 is not a member of ‘{ x :: Number, y :: Number }’.\n'));
+                   'The value at position 1 is not a member of ‘Number’.\n'));
 
     throws(function() { length({start: 0, end: 0}); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
                    'length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number\n' +
-                   '          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                   '                                                1\n' +
+                   '                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+                   '                                1\n' +
                    '\n' +
-                   '1)  {"end": 0, "start": 0} :: Object, StrMap Number\n' +
+                   '1)  0 :: Number\n' +
                    '\n' +
-                   'The value at position 1 is not a member of ‘{ end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } }’.\n'));
+                   'The value at position 1 is not a member of ‘{ x :: Number, y :: Number }’.\n'));
+
+    throws(function() { length({start: {x: 0, y: 0}, end: {x: null, y: null}}); },
+           errorEq(TypeError,
+                   'Invalid value\n' +
+                   '\n' +
+                   'length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number\n' +
+                   '                          ^^^^^^\n' +
+                   '                            1\n' +
+                   '\n' +
+                   '1)  null :: Null\n' +
+                   '\n' +
+                   'The value at position 1 is not a member of ‘Number’.\n'));
 
     //  id :: a -> a
     var id = def('id', {}, [a, a], R.identity);


### PR DESCRIPTION
Alternative to #30

Commit message:

> When we determine that a value is not a member of the specified record type, we do not currently make the reason clear: we underline the type's entire string representation even if just one field is invalid.
>
> This problem compounds with nesting, since the outermost record type is underlined regardless of the depth at which validation fails.
>
> This commit updates the `underline` function to draw attention to the invalid field.
>
> Invalid `position.x`, before:
>
>     { color :: String, position :: { x :: Number, y :: Number } }
>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> Invalid `position.x`, after:
>
>     { color :: String, position :: { x :: Number, y :: Number } }
>                                           ^^^^^^

Before:

```javascript
length({start: {x: 0, y: 0}, end: {x: null, y: null}});
// ! TypeError: Invalid value
//
//   length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number
//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                                                   1
//
//   1)  {"end": {"x": null, "y": null}, "start": {"x": 0, "y": 0}} :: Object, StrMap Object
//
//   The value at position 1 is not a member of ‘{ end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } }’.
```

After:

```javascript
length({start: {x: 0, y: 0}, end: {x: null, y: null}});
// ! TypeError: Invalid value
//
//   length :: { end :: { x :: Number, y :: Number }, start :: { x :: Number, y :: Number } } -> Number
//                             ^^^^^^
//                               1
//
//   1)  null :: Null
//
//   The value at position 1 is not a member of ‘Number’.
```

Do you think this would ease your pain, @rbuckheit?
